### PR TITLE
Style Auth Pages and Rename App Display Name

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">setup</string>
+    <string name="app_name">ElectrifAI</string>
 </resources>

--- a/app.json
+++ b/app.json
@@ -1,4 +1,4 @@
 {
   "name": "setup",
-  "displayName": "setup"
+  "displayName": "ElectrifAI"
 }

--- a/ios/setup/Info.plist
+++ b/ios/setup/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>setup</string>
+	<string>ElectrifAI</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -20,7 +20,7 @@ const AuthNavigator = () => {
       <AuthStack.Screen
         name="Register"
         component={RegisterScreen}
-        options={{ title: 'Register' }}
+        options={{ headerShown: false, title: 'Register' }}
       />
     </AuthStack.Navigator>
   );

--- a/src/screens/Auth/LoginScreen.tsx
+++ b/src/screens/Auth/LoginScreen.tsx
@@ -94,7 +94,6 @@ const styles = StyleSheet.create({
   },
   button: {
     width: "80%",
-    paddingVertical: 14,
     borderRadius: 8,
     alignItems: "center",
     marginTop: 20,
@@ -102,6 +101,7 @@ const styles = StyleSheet.create({
   innerButton: {
     width: "100%",
     alignItems: 'center',
+    paddingVertical: 14,
   },
   buttonText: {
     color: "#fff",

--- a/src/screens/Auth/LoginScreen.tsx
+++ b/src/screens/Auth/LoginScreen.tsx
@@ -23,17 +23,17 @@ export default function Login() {
         source={require('../../assets/images/logo.png')}
         style={styles.logo}
       />
-      <Text style={styles.title}>Project ElectriAI</Text>
+      {/* <Text style={styles.title}>Project ElectriAI</Text> */}
       <TextInput
         placeholder="Email"
         style={styles.input}
-        placeholderTextColor="#D4820C"
+        placeholderTextColor="#2D3142"
       />
       <TextInput
         placeholder="Password"
         secureTextEntry
         style={styles.input}
-        placeholderTextColor="#D4820C"
+        placeholderTextColor="#2D3142"
       />
       <TouchableOpacity style={styles.button} onPress={handleLogin}>
         <Text style={styles.buttonText}>Login</Text>
@@ -75,17 +75,16 @@ const styles = StyleSheet.create({
   },
   input: {
     width: "80%",
-    borderWidth: 1,
-    borderColor: "#D4820C",
     padding: 10,
     margin: 10,
     borderRadius: 4,
     color: "#000",
-    backgroundColor: "#fff",
+    backgroundColor: "#f9f9fb",
+    elevation: 4,
   },
   button: {
     width: "80%",
-    backgroundColor: "#FFB315",
+    backgroundColor: "#2D3142",
     padding: 14,
     borderRadius: 8,
     alignItems: "center",
@@ -104,7 +103,7 @@ const styles = StyleSheet.create({
     color: "#000",
   },
   signupLink: {
-    color: "#FFB315",
+    color: "#2D3142",
     marginLeft: 5,
     fontWeight: "bold",
   },

--- a/src/screens/Auth/LoginScreen.tsx
+++ b/src/screens/Auth/LoginScreen.tsx
@@ -3,6 +3,7 @@ import { TouchableOpacity } from "react-native";
 import { Text, View } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { RootStackNavigationProp } from "../types";
+import LinearGradient from "react-native-linear-gradient";
 
 
 export default function Login() {
@@ -35,9 +36,18 @@ export default function Login() {
         style={styles.input}
         placeholderTextColor="#2D3142"
       />
-      <TouchableOpacity style={styles.button} onPress={handleLogin}>
-        <Text style={styles.buttonText}>Login</Text>
-      </TouchableOpacity>
+      <LinearGradient
+        colors={['#333E6C', '#2D3142']}
+        locations={[0, 0.66]}
+        style={styles.button}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+      >
+        <TouchableOpacity style={styles.innerButton} onPress={handleLogin}>
+          <Text style={styles.buttonText}>Login</Text>
+        </TouchableOpacity>
+      </LinearGradient>
+  
      <View style={styles.signupContainer}>
         <Text style={styles.signupText}>Don't have an account yet?</Text>
         <TouchableOpacity
@@ -84,11 +94,14 @@ const styles = StyleSheet.create({
   },
   button: {
     width: "80%",
-    backgroundColor: "#2D3142",
-    padding: 14,
+    paddingVertical: 14,
     borderRadius: 8,
     alignItems: "center",
     marginTop: 20,
+  },
+  innerButton: {
+    width: "100%",
+    alignItems: 'center',
   },
   buttonText: {
     color: "#fff",

--- a/src/screens/Auth/RegisterScreen.tsx
+++ b/src/screens/Auth/RegisterScreen.tsx
@@ -22,27 +22,27 @@ export default function Signup() {
         source={require('../../assets/images/logo.png')}
         style={styles.logo}
       />
-      <Text style={styles.title}>Sign Up</Text>
+      <Text style={styles.title}>Create an Account</Text>
       <TextInput
         placeholder="First Name"
         style={styles.input}
-        placeholderTextColor="#D4820C"
+        placeholderTextColor="#2D3142"
       />
       <TextInput
         placeholder="Last Name"
         style={styles.input}
-        placeholderTextColor="#D4820C"
+        placeholderTextColor="#2D3142"
       />
       <TextInput
         placeholder="Email"
         style={styles.input}
-        placeholderTextColor="#D4820C"
+        placeholderTextColor="#2D3142"
       />
       <TextInput
         placeholder="Password"
         secureTextEntry
         style={styles.input}
-        placeholderTextColor="#D4820C"
+        placeholderTextColor="#2D3142"
       />
       <TouchableOpacity style={styles.button} onPress={handleSignup}>
         <Text style={styles.buttonText}>Sign Up</Text>
@@ -79,22 +79,21 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 24,
     fontWeight: "bold",
-    color: "#FFB315",
+    color: "#2D3142",
     marginBottom: 20,
   },
   input: {
     width: "80%",
-    borderWidth: 1,
-    borderColor: "#D4820C",
     padding: 10,
     margin: 10,
     borderRadius: 4,
     color: "#000",
-    backgroundColor: "#fff",
+    backgroundColor: "#f9f9fb",
+    elevation: 4,
   },
   button: {
     width: "80%",
-    backgroundColor: "#FFB315",
+    backgroundColor: "#2D3142",
     padding: 14,
     borderRadius: 8,
     alignItems: "center",
@@ -113,7 +112,7 @@ const styles = StyleSheet.create({
     color: "#000",
   },
   loginLink: {
-    color: "#FFB315",
+    color: "#2D3142",
     marginLeft: 5,
     fontWeight: "bold",
   },

--- a/src/screens/Auth/RegisterScreen.tsx
+++ b/src/screens/Auth/RegisterScreen.tsx
@@ -3,6 +3,8 @@ import { StyleSheet, TextInput, Image } from "react-native";
 import { Text, View } from "react-native";
 import { TouchableOpacity } from "react-native";
 import { RootStackNavigationProp } from "../types";
+import LinearGradient from "react-native-linear-gradient";
+
 
 export default function Signup() {
   const navigate = useNavigation<RootStackNavigationProp>()
@@ -44,9 +46,17 @@ export default function Signup() {
         style={styles.input}
         placeholderTextColor="#2D3142"
       />
-      <TouchableOpacity style={styles.button} onPress={handleSignup}>
-        <Text style={styles.buttonText}>Sign Up</Text>
-      </TouchableOpacity>
+      <LinearGradient
+        colors={['#333E6C', '#2D3142']}
+        locations={[0, 0.66]}
+        style={styles.button}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+      >
+        <TouchableOpacity style={styles.innerButton} onPress={handleSignup}>
+          <Text style={styles.buttonText}>Sign Up</Text>
+        </TouchableOpacity>
+      </LinearGradient>
       <View style={styles.loginContainer}>
         <Text style={styles.loginText}>Already have an account?</Text>
         <TouchableOpacity 
@@ -59,6 +69,7 @@ export default function Signup() {
         >
           <Text style={styles.loginLink}> Login</Text>
         </TouchableOpacity>
+      
       </View>
     </View>
   );
@@ -93,11 +104,14 @@ const styles = StyleSheet.create({
   },
   button: {
     width: "80%",
-    backgroundColor: "#2D3142",
-    padding: 14,
+    paddingVertical: 14,
     borderRadius: 8,
     alignItems: "center",
     marginTop: 20,
+  },
+  innerButton: {
+    width: "100%",
+    alignItems: 'center',
   },
   buttonText: {
     color: "#fff",

--- a/src/screens/Auth/RegisterScreen.tsx
+++ b/src/screens/Auth/RegisterScreen.tsx
@@ -104,13 +104,13 @@ const styles = StyleSheet.create({
   },
   button: {
     width: "80%",
-    paddingVertical: 14,
     borderRadius: 8,
     alignItems: "center",
     marginTop: 20,
   },
   innerButton: {
     width: "100%",
+    paddingVertical: 14,
     alignItems: 'center',
   },
   buttonText: {


### PR DESCRIPTION
### Description
This pull request includes the following changes:

- Update colors of buttons in Login Screen and Register Screen
- Rename app name displayed for Android and IOS
- Hide header when on Register Screen

### Screenshots
#### Login Screen
##### Before
![Screenshot_1725655786](https://github.com/user-attachments/assets/8ac72749-45fd-4d43-a7be-760d3896e8a0)
##### After
![Screenshot_1725656087](https://github.com/user-attachments/assets/40530e3a-1bb1-4f50-a4cb-30a785ca016f)

#### Register Screen
Before
![Screenshot_1725655810](https://github.com/user-attachments/assets/1b9e0b4f-dab8-4c1f-a585-203dfd91f31d)
After
![Screenshot_1725656090](https://github.com/user-attachments/assets/b01228b6-7485-4750-a00e-f92c15883a46)

#### App Name
Before
![Screenshot_1725655815](https://github.com/user-attachments/assets/993a9257-0aac-43e4-ad56-eaccbb0dd370)
After
![Screenshot_1725655596](https://github.com/user-attachments/assets/d35795fe-b047-4b78-940e-c57dc370250e)
